### PR TITLE
Add extended version installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ asdf list-all hugo
 # Install specific version
 asdf install hugo latest
 
+# Install specific extended version (for Sass/SCSS support)
+asdf install hugo extended_X.Y.Z
+
 # Set a version globally (on your ~/.tool-versions file)
 asdf global hugo latest
 


### PR DESCRIPTION
This is to allow Hugo users to have Sass/SCSS support. Installation works with the `extended_` version prefix (validated with 0.100.0). 