### PR TITLE
fix(utils): unbreak macOS downloads for v0.104.3

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -75,6 +75,7 @@ download_release() {
   macOS) arch="universal" ;;
   *)
     arch="$(get_arch)"
+    platform="darwin"
     ;;
   esac
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -72,10 +72,12 @@ download_release() {
   filename="$2"
   platform="$(get_platform)"
   case "${platform}" in
-  macOS) arch="universal" ;;
+  macOS) 
+    arch="universal"
+    platform="darwin"
+    ;;
   *)
     arch="$(get_arch)"
-    platform="darwin"
     ;;
   esac
 


### PR DESCRIPTION
**What this PR does**: This PR changes the `platform` string used for downloading on macOS to be `darwin`. Here's the release name from `0.104.3`:

 * `hugo_0.104.3_darwin-universal.tar.gz`