### PR TITLE
Handle change in macOS release naming

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -72,7 +72,14 @@ download_release() {
   filename="$2"
   platform="$(get_platform)"
   case "${platform}" in
-  macOS) arch="universal" ;;
+  macOS)
+    version_minor="${version#*.}"
+    version_minor="${version_minor%.*}"
+    if [ $version_minor -ge 103 ]; then
+      platform="darwin"
+    fi
+    arch="universal"
+    ;;
   *)
     arch="$(get_arch)"
     ;;


### PR DESCRIPTION
Hugo changed macOS release binary naming starting with v0.103.

This change supports both URL formats based on the version minor value.

Previous naming: `hugo_extended_0.102.3_macOS-universal.tar.gz`
New naming: `hugo_extended_0.103.1_darwin-universal.tar.gz`

Fixes #6 