### PR TITLE
Support macOS asset naming scheme for versions prior to v0.102.0

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -70,6 +70,7 @@ download_release() {
   version="$1"
   version_path="${version//extended_/}"
   filename="$2"
+  arch="$(get_arch)"
   platform="$(get_platform)"
   case "${platform}" in
   macOS)
@@ -78,10 +79,10 @@ download_release() {
     if [ $version_minor -ge 103 ]; then
       platform="darwin"
     fi
-    arch="universal"
-    ;;
-  *)
-    arch="$(get_arch)"
+
+    if [ $version_minor -ge 102 ]; then
+      arch="universal"
+    fi
     ;;
   esac
 


### PR DESCRIPTION
Closes #9 

# Overview
As described in #9, there was a change in the hugo naming scheme for macOS releases, which this plugin hasn't taken into account. The issue in question describes a problem with installing version 0.99.1, but the problem exists for all versions up-to-and-including 0.101.0.

To demonstrate the problem, version [v0.102.0](https://github.com/gohugoio/hugo/releases/tag/v0.102.0) includes the following macOS assets:
- [hugo_0.102.0_macOS-universal.tar.gz](https://github.com/gohugoio/hugo/releases/download/v0.102.0/hugo_0.102.0_macOS-universal.tar.gz)
- [hugo_extended_0.102.0_macOS-universal.tar.gz](https://github.com/gohugoio/hugo/releases/download/v0.102.0/hugo_extended_0.102.0_macOS-universal.tar.gz)

Whereas the version preceding it, [v0.101.0](https://github.com/gohugoio/hugo/releases/tag/v0.101.0), has the following macOS assets:
- [hugo_0.101.0_macOS-64bit.tar.gz](https://github.com/gohugoio/hugo/releases/download/v0.101.0/hugo_0.101.0_macOS-64bit.tar.gz)
- [hugo_0.101.0_macOS-ARM64.tar.gz](https://github.com/gohugoio/hugo/releases/download/v0.101.0/hugo_0.101.0_macOS-ARM64.tar.gz)
- [hugo_extended_0.101.0_macOS-64bit.tar.gz](https://github.com/gohugoio/hugo/releases/download/v0.101.0/hugo_extended_0.101.0_macOS-64bit.tar.gz)
- [hugo_extended_0.101.0_macOS-ARM64.tar.gz](https://github.com/gohugoio/hugo/releases/download/v0.101.0/hugo_extended_0.101.0_macOS-ARM64.tar.gz)

So, they seem to have replaced `universal` with architecture specific assets, but only for versions prior to v0.102.0.

# Change Summary
This PR updates the util function `download_release()` to set the `arch` part of the hugo asset URL to `universal` for macOS, only if the version is greater than or equal to v0.102.0.